### PR TITLE
clear products list before every new generation

### DIFF
--- a/src/main/java/Main.java
+++ b/src/main/java/Main.java
@@ -24,12 +24,12 @@ public class Main {
 
         // populate some data for the memory storage
         populateData();
-        ProductDaoJdbc produ = ProductDaoJdbc.getInstance() ;
+//        ProductDaoJdbc produ = ProductDaoJdbc.getInstance() ;
         SupplierDaoJdbc supp = SupplierDaoJdbc.getInstance();
         ProductCategoryDaoJdbc prodCat = ProductCategoryDaoJdbc.getInstance();
         System.out.println(supp.generateSuppliers());
         System.out.println(prodCat.generateProductCategories());
-        System.out.println(produ.generateProducts());
+//        System.out.println(produ.generateProducts());
         ShoppingCart cart = ShoppingCart.getInstance();
 
         // Always add generic routes to the end

--- a/src/main/java/com/codecool/shop/controller/ProductController.java
+++ b/src/main/java/com/codecool/shop/controller/ProductController.java
@@ -4,6 +4,7 @@ import com.codecool.shop.dao.ProductCategoryDao;
 import com.codecool.shop.dao.ProductDao;
 import com.codecool.shop.dao.SupplierDao;
 import com.codecool.shop.dao.implementation.ProductCategoryDaoMem;
+import com.codecool.shop.dao.implementation.ProductDaoJdbc;
 import com.codecool.shop.dao.implementation.ProductDaoMem;
 import com.codecool.shop.dao.implementation.SupplierDaoMem;
 import com.codecool.shop.model.Product;
@@ -22,9 +23,9 @@ import java.util.Map;
 public class ProductController {
 
     public static ModelAndView renderAllProducts(Request req, Response res) {
-        ProductDao productDataStore = ProductDaoMem.getInstance();
+        ProductDaoJdbc productDataStore = ProductDaoJdbc.getInstance();
         HashMap<String, List> params = new HashMap<>();
-        params.put("products", productDataStore.getAll());
+        params.put("products", productDataStore.generateProducts());
         System.out.println(params);
         return new ModelAndView(params, "product/index");
     }

--- a/src/main/java/com/codecool/shop/dao/implementation/ProductDaoJdbc.java
+++ b/src/main/java/com/codecool/shop/dao/implementation/ProductDaoJdbc.java
@@ -25,6 +25,7 @@ public class ProductDaoJdbc extends DBConnection{
 
     //    @Override
     public ArrayList<Product> generateProducts() {
+        products.clear();
 
         String query = "SELECT * FROM product;";
 


### PR DESCRIPTION
On the website, the generateProducts method ran every time you hit refresh and duplicated the products list... solution was clearing the products list before querying from the DB.